### PR TITLE
Emacs should load faster when opening source code with spelling errors

### DIFF
--- a/emacs-stuff/.emacs.d/init.el
+++ b/emacs-stuff/.emacs.d/init.el
@@ -229,6 +229,7 @@ find-dominating-file?"
     (scroll-bar-mode -1)
   (error nil))
 (global-auto-complete-mode -1)
+(setq flyspell-issue-message-flag nil)
 
 ;; Turn on the good shit
 (transient-mark-mode 1)


### PR DESCRIPTION
flyspell-prog-mode apparently is much faster with
`flyspell-issue-message-flag` set to `nil`...