### PR TITLE
emacs-ycmd faster to suggest autocomplete

### DIFF
--- a/emacs-stuff/.emacs.d/init.el
+++ b/emacs-stuff/.emacs.d/init.el
@@ -547,7 +547,6 @@ executed (thus updating the TAGS file). "
 (require 'ycmd)
 (require 'company-ycmd)
 (require 'flycheck-ycmd)
-(add-hook 'after-init-hook #'global-ycmd-mode)
 (setq ycmd-server-command (list "python" (file-truename "~/documents/git/ycmd/ycmd")))
 (ycmd-setup)
 (company-ycmd-setup)
@@ -556,7 +555,8 @@ executed (thus updating the TAGS file). "
   (ycmd-mode) (company-mode) (flycheck-mode))
 (add-hook 'c++-mode-hook 'enable-ycmd)
 (add-hook 'c-mode-hook 'enable-ycmd)
-(setq company-idle-delay 0.2)
+(add-hook 'python-mode-hook 'enable-ycmd)
+(setq company-idle-delay 0.05)
 (setq company-ycmd-request-sync-timeout 0)
 
 ;; Bind Shift + TAB to force semantic completion

--- a/emacs-stuff/.emacs.d/lisp/dired-mod.el
+++ b/emacs-stuff/.emacs.d/lisp/dired-mod.el
@@ -93,10 +93,10 @@ Otherwise, an error occurs in these cases."
 
     (when (= (safe-length marked-files) 2)
       (ediff-files (nth 0 marked-files) (nth 1 marked-files)))
-    
+
     (when (= (safe-length marked-files) 3)
       (ediff3 (buffer-file-name (nth 0 marked-files))
-	      (buffer-file-name (nth 1 marked-files)) 
+	      (buffer-file-name (nth 1 marked-files))
 	      (buffer-file-name (nth 2 marked-files))))))
 
 (defun dired-vc-status-dir ()
@@ -112,7 +112,7 @@ Otherwise, an error occurs in these cases."
     (with-temp-buffer
       (apply 'call-process "/usr/bin/du" nil t nil "-sch" files)
       (message "Size of all marked files: %s"
-               (progn 
+               (progn
                  (re-search-backward "\\(^[0-9.,]+[A-Za-z]+\\).*total$")
 		 (match-string 1))))))
 
@@ -138,7 +138,7 @@ Otherwise, an error occurs in these cases."
   (interactive)
   (let* ((subdir-name (dired-current-directory))
 	 (parent-dir  (file-name-directory (directory-file-name subdir-name)))
-	 (search-term (concat " " (file-basename subdir-name))))
+	 (search-term (concat " " (file-name-nondirectory (directory-file-name subdir-name)))))
     (dired-kill-subdir)
     (dired-goto-subdir parent-dir)
     (search-forward search-term)))


### PR DESCRIPTION
fixed '^' key in dired ('go up one directory') not working. Note that
M-p does the same thing, is built-in, and more flexible.