### PR TITLE
konsole: don't save geometry on exit

### DIFF
--- a/konsole-stuff/konsolerc
+++ b/konsole-stuff/konsolerc
@@ -4,9 +4,12 @@ DefaultProfile=Paul.profile
 [Favorite Profiles]
 Favorites=
 
+[KonsoleWindow]
+SaveGeometryOnExit=false
+
 [MainWindow]
-Height 1440=1416
+Height 1440[$d]
 MenuBar=Disabled
 State=AAAA/wAAAAD9AAAAAAAABPwAAAWIAAAABAAAAAQAAAAIAAAACPwAAAAA
 ToolBarsMovable=Disabled
-Width 2560=1276
+Width 2560[$d]


### PR DESCRIPTION
You need to access this setting via the menu bar (right click, 'Show
Menu Bar') and going to 'Configure konsole'.