### PR TITLE
Add config for tmux (uses C-\ as the default prefix)

### DIFF
--- a/applysettings.py
+++ b/applysettings.py
@@ -161,6 +161,9 @@ linkPairs = [
     (os.path.join(scriptDir, 'oh-my-zsh'),
      os.path.join(homeDir, '.oh-my-zsh')),
 
+    (os.path.join(scriptDir, 'tmux-stuff', 'tmux.conf'),
+     os.path.join(homeDir, '.tmux.conf')),
+
 ]
 
 #add all the stuff in the 'bin' directory to linkPairs

--- a/tmux-stuff/tmux.conf
+++ b/tmux-stuff/tmux.conf
@@ -1,0 +1,7 @@
+# Remap prefix from 'C-b' to 'C-/'
+unbind-key C-b
+set -g prefix 'C-\'
+bind-key 'C-\' send-prefix
+
+# Use 256 when running e.g. emacs in tmux
+set -g default-terminal "screen-256color"


### PR DESCRIPTION
Also uses 256 colors when running emacs in tmux.