### PR TITLE
Don't hard-code the version of clang-format to use

### DIFF
--- a/emacs-stuff/.emacs.d/lisp/clang-format.el
+++ b/emacs-stuff/.emacs.d/lisp/clang-format.el
@@ -36,9 +36,8 @@
   :group 'tools)
 
 (defcustom clang-format-executable
-  (or (executable-find "clang-format-4.0")
-      "clang-format")
-  "Location of the clang-format executable.
+  (executable-find "clang-format")
+    "Location of the clang-format executable.
 
 A string containing the name or the full path of the executable."
   :group 'clang-format


### PR DESCRIPTION
This means that if using a custom version of clang-format, just add it
as a symlink (~/bin/clang-format).