### PR TITLE
Update clang-format.el

### DIFF
--- a/emacs-stuff/.emacs.d/lisp/clang-format.el
+++ b/emacs-stuff/.emacs.d/lisp/clang-format.el
@@ -1,4 +1,4 @@
-;;; clang-format.el --- Format code using clang-format
+;;; clang-format.el --- Format code using clang-format  -*- lexical-binding: t; -*-
 
 ;; Keywords: tools, c
 ;; Package-Requires: ((cl-lib "0.3"))
@@ -15,7 +15,7 @@
 ;;   M-x package-install clang-format
 ;;
 ;; when ("melpa" . "http://melpa.org/packages/") is included in
-;; `package-archives'. Alternatively, ensure the directory of this
+;; `package-archives'.  Alternatively, ensure the directory of this
 ;; file is in your `load-path' and add
 ;;
 ;;   (require 'clang-format)
@@ -36,12 +36,13 @@
   :group 'tools)
 
 (defcustom clang-format-executable
-  (executable-find "clang-format")
-    "Location of the clang-format executable.
+  (or (executable-find "clang-format-6.0")
+      "clang-format")
+  "Location of the clang-format executable.
 
 A string containing the name or the full path of the executable."
   :group 'clang-format
-  :type 'string
+  :type '(file :must-match t)
   :risky t)
 
 (defcustom clang-format-style "file"
@@ -60,6 +61,7 @@ of the buffer."
   (unless (and (listp xml-node) (eq (xml-node-name xml-node) 'replacements))
     (error "Expected <replacements> node"))
   (let ((nodes (xml-node-children xml-node))
+        (incomplete-format (xml-get-attribute xml-node 'incomplete_format))
         replacements
         cursor)
     (dolist (node nodes)
@@ -75,11 +77,11 @@ of the buffer."
                (when (cdr children)
                  (error "More than one child node in <replacement> node"))
 
-               (setq offset (1+ (string-to-number offset)))
+               (setq offset (string-to-number offset))
                (setq length (string-to-number length))
                (push (list offset length text) replacements)))
             ('cursor
-             (setq cursor (1+ (string-to-number text))))))))
+             (setq cursor (string-to-number text)))))))
 
     ;; Sort by decreasing offset, length.
     (setq replacements (sort (delq nil replacements)
@@ -88,19 +90,41 @@ of the buffer."
                                    (and (= (car a) (car b))
                                         (> (cadr a) (cadr b)))))))
 
-    (cons replacements cursor)))
+    (list replacements cursor (string= incomplete-format "true"))))
 
 (defun clang-format--replace (offset length &optional text)
-  (goto-char offset)
-  (delete-char length)
-  (when text
-    (insert text)))
+  "Replace the region defined by OFFSET and LENGTH with TEXT.
+OFFSET and LENGTH are measured in bytes, not characters.  OFFSET
+is a zero-based file offset, assuming ‘utf-8-unix’ coding."
+  (let ((start (clang-format--filepos-to-bufferpos offset 'exact 'utf-8-unix))
+        (end (clang-format--filepos-to-bufferpos (+ offset length) 'exact
+                                                 'utf-8-unix)))
+    (goto-char start)
+    (delete-region start end)
+    (when text
+      (insert text))))
+
+;; ‘bufferpos-to-filepos’ and ‘filepos-to-bufferpos’ are new in Emacs 25.1.
+;; Provide fallbacks for older versions.
+(defalias 'clang-format--bufferpos-to-filepos
+  (if (fboundp 'bufferpos-to-filepos)
+      'bufferpos-to-filepos
+    (lambda (position &optional _quality _coding-system)
+      (1- (position-bytes position)))))
+
+(defalias 'clang-format--filepos-to-bufferpos
+  (if (fboundp 'filepos-to-bufferpos)
+      'filepos-to-bufferpos
+    (lambda (byte &optional _quality _coding-system)
+      (byte-to-position (1+ byte)))))
 
 ;;;###autoload
-(defun clang-format-region (start end &optional style)
+(defun clang-format-region (start end &optional style assume-file-name)
   "Use clang-format to format the code between START and END according to STYLE.
-If called interactively uses the region or the current statement if there
-is no active region.  If no style is given uses `clang-format-style'."
+If called interactively uses the region or the current statement if there is no
+no active region. If no STYLE is given uses `clang-format-style'. Use
+ASSUME-FILE-NAME to locate a style config file, if no ASSUME-FILE-NAME is given
+uses the function `buffer-file-name'."
   (interactive
    (if (use-region-p)
        (list (region-beginning) (region-end))
@@ -109,55 +133,71 @@ is no active region.  If no style is given uses `clang-format-style'."
   (unless style
     (setq style clang-format-style))
 
-  (let ((temp-buffer (generate-new-buffer " *clang-format-temp*"))
-        (temp-file (make-temp-file "clang-format")))
+  (unless assume-file-name
+    (setq assume-file-name buffer-file-name))
+
+  (let ((file-start (clang-format--bufferpos-to-filepos start 'approximate
+                                                        'utf-8-unix))
+        (file-end (clang-format--bufferpos-to-filepos end 'approximate
+                                                      'utf-8-unix))
+        (cursor (clang-format--bufferpos-to-filepos (point) 'exact 'utf-8-unix))
+        (temp-buffer (generate-new-buffer " *clang-format-temp*"))
+        (temp-file (make-temp-file "clang-format"))
+        ;; Output is XML, which is always UTF-8.  Input encoding should match
+        ;; the encoding used to convert between buffer and file positions,
+        ;; otherwise the offsets calculated above are off.  For simplicity, we
+        ;; always use ‘utf-8-unix’ and ignore the buffer coding system.
+        (default-process-coding-system '(utf-8-unix . utf-8-unix)))
     (unwind-protect
-        (let (status stderr operations)
-          (setq status
-                (call-process-region
-                 (point-min) (point-max) clang-format-executable
-                 nil `(,temp-buffer ,temp-file) nil
-
-                 "-output-replacements-xml"
-                 "-assume-filename" (or (buffer-file-name) "")
-                 "-style" style
-                 "-offset" (number-to-string (1- start))
-                 "-length" (number-to-string (- end start))
-                 "-cursor" (number-to-string (1- (point)))))
-          (setq stderr
-                (with-temp-buffer
-                  (insert-file-contents temp-file)
-                  (when (> (point-max) (point-min))
-                    (insert ": "))
-                  (buffer-substring-no-properties
-                   (point-min) (line-end-position))))
-
+        (let ((status (apply #'call-process-region
+                             nil nil clang-format-executable
+                             nil `(,temp-buffer ,temp-file) nil
+                             `("-output-replacements-xml"
+                               ;; Gaurd against a nil assume-file-name.
+                               ;; If the clang-format option -assume-filename
+                               ;; is given a blank string it will crash as per
+                               ;; the following bug report
+                               ;; https://bugs.llvm.org/show_bug.cgi?id=34667
+                               ,@(and assume-file-name
+                                      (list "-assume-filename" assume-file-name))
+                               "-style" ,style
+                               "-offset" ,(number-to-string file-start)
+                               "-length" ,(number-to-string (- file-end file-start))
+                               "-cursor" ,(number-to-string cursor))))
+              (stderr (with-temp-buffer
+                        (unless (zerop (cadr (insert-file-contents temp-file)))
+                          (insert ": "))
+                        (buffer-substring-no-properties
+                         (point-min) (line-end-position)))))
           (cond
            ((stringp status)
             (error "(clang-format killed by signal %s%s)" status stderr))
-           ((not (equal 0 status))
-            (error "(clang-format failed with code %d%s)" status stderr))
-           (t (message "(clang-format succeeded%s)" stderr)))
+           ((not (zerop status))
+            (error "(clang-format failed with code %d%s)" status stderr)))
 
-          (with-current-buffer temp-buffer
-            (setq operations (clang-format--extract (car (xml-parse-region)))))
-
-          (let ((replacements (car operations))
-                (cursor (cdr operations)))
+          (cl-destructuring-bind (replacements cursor incomplete-format)
+              (with-current-buffer temp-buffer
+                (clang-format--extract (car (xml-parse-region))))
             (save-excursion
-              (mapc (lambda (rpl)
-                      (apply #'clang-format--replace rpl))
-                    replacements))
+              (dolist (rpl replacements)
+                (apply #'clang-format--replace rpl)))
             (when cursor
-              (goto-char cursor))))
+              (goto-char (clang-format--filepos-to-bufferpos cursor 'exact
+                                                             'utf-8-unix)))
+            (if incomplete-format
+                (message "(clang-format: incomplete (syntax errors)%s)" stderr)
+              (message "(clang-format: success%s)" stderr))))
       (delete-file temp-file)
       (when (buffer-name temp-buffer) (kill-buffer temp-buffer)))))
 
 ;;;###autoload
-(defun clang-format-buffer (&optional style)
-  "Use clang-format to format the current buffer according to STYLE."
+(defun clang-format-buffer (&optional style assume-file-name)
+  "Use clang-format to format the current buffer according to STYLE.
+If no STYLE is given uses `clang-format-style'. Use ASSUME-FILE-NAME
+to locate a style config file. If no ASSUME-FILE-NAME is given uses
+the function `buffer-file-name'."
   (interactive)
-  (clang-format-region (point-min) (point-max) style))
+  (clang-format-region (point-min) (point-max) style assume-file-name))
 
 ;;;###autoload
 (defalias 'clang-format 'clang-format-region)


### PR DESCRIPTION
New version is copied from
`/usr/share/emacs/site-lisp/clang-format-6.0/clang-format.el` on Ubuntu
18.04.

This fixes incorrect formatting when the file has special characters in
it (such as those printed by the `tree` command).