### PR TITLE
Add python support to lsp-mode

### DIFF
--- a/emacs-stuff/.emacs.d/init.el
+++ b/emacs-stuff/.emacs.d/init.el
@@ -546,4 +546,6 @@ executed (thus updating the TAGS file). "
 ;; auto-complete setup for C++.
 (require 'lsp-mode)
 (add-hook 'c++-mode-hook #'lsp)
+(add-hook 'python-mode-hook #'lsp)
 (setq company-idle-delay 0.05)
+(setq lsp-enable-symbol-highlighting nil)


### PR DESCRIPTION
To install and have a basic config:

1. pip3 install python-language-server[all]

2. Add a setup.cfg in your repo containing the following:
[pycodestyle]
max-line-length = 120