### PR TITLE
xsession: Fix xterm not using Alt key (e.g., Alt-b)

### DIFF
--- a/applysettings.py
+++ b/applysettings.py
@@ -153,6 +153,9 @@ def _main():
         (os.path.join(SCRIPT_DIR, 'linux-stuff', '.xsession'),
          os.path.join(HOME_DIR, '.xsession')),
 
+        (os.path.join(SCRIPT_DIR, 'linux-stuff', '.xinitrc'),
+         os.path.join(HOME_DIR, '.xinitrc')),
+
         (os.path.join(SCRIPT_DIR, 'i3-stuff', 'i3'),
          os.path.join(HOME_DIR, '.i3')),
 

--- a/linux-stuff/.xinitrc
+++ b/linux-stuff/.xinitrc
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+xmodmap ${HOME}/.keyboard-modifier-layout
+xmodmap ${HOME}/.keyboard-key-layout
+xset r rate 300 40


### PR DESCRIPTION
Apparently the right place to put xmodmap commands is in ~/.xinitrc, not
~/.xsession. https://askubuntu.com/a/211461