### PR TITLE
xsession: Fix xterm not using Alt key (e.g., Alt-b

### DIFF
--- a/applysettings.py
+++ b/applysettings.py
@@ -105,8 +105,10 @@ def _main():
         (os.path.join(SCRIPT_DIR, 'icons'),
          os.path.join(HOME_DIR, '.icons')),
 
+        # This *has* to be called ~/.xmodmap, otherwise xterm won't correctly
+        # handle Alt keys (e.g., Alt-b).
         (os.path.join(SCRIPT_DIR, 'linux-stuff', 'keyboard-key-layout'),
-         os.path.join(HOME_DIR, '.keyboard-key-layout')),
+         os.path.join(HOME_DIR, '.xmodmap')),
 
         (os.path.join(SCRIPT_DIR, 'linux-stuff', 'keyboard-modifier-layout'),
          os.path.join(HOME_DIR, '.keyboard-modifier-layout')),

--- a/linux-stuff/.xsession
+++ b/linux-stuff/.xsession
@@ -27,7 +27,8 @@ nm-applet --sm-disable &
 gnome-screensaver &
 
 xmodmap ${HOME}/.keyboard-modifier-layout
-xmodmap ${HOME}/.keyboard-key-layout
+# We assume xmodmap ${HOME}/.xmodmap gets run automatically. Indeed, if you run
+# that command here xterm won't correctly handle Alt keys (e.g., Alt-b).
 xset r rate 300 40
 
 # Disable uber annoying overlay scroll bar.


### PR DESCRIPTION
Apparently explicitly calling xmodmap ~/.xmodmap in .xsession causes
xterm to incorrectly handle Alt keys (e.g., Alt-b).