### PR TITLE
Removing [user] field from .gitconfig

### DIFF
--- a/git-stuff/.gitconfig
+++ b/git-stuff/.gitconfig
@@ -1,7 +1,3 @@
-[user]
-	name = Paul Ozog
-	email = pjozog@gmail.com
-
 [color]
 	ui = auto
 


### PR DESCRIPTION
Too many times has my personal email found its way into my work's repo's private commits...