### PR TITLE
Speed up blur-lock

### DIFF
--- a/linux-stuff/bin/blur-lock
+++ b/linux-stuff/bin/blur-lock
@@ -17,7 +17,7 @@ get_blocky_res() {
     echo $((${SHARPNESS} * $(get_num_conn_monitors)))
 }
 
-import -window root /tmp/screen_locked.png
-convert /tmp/screen_locked.png -scale $(get_blocky_res) -scale $(get_screen_res) /tmp/screen_locked2.png
+import -window root /tmp/screen_locked.bmp
+convert /tmp/screen_locked.bmp -scale $(get_blocky_res) -scale $(get_screen_res) /tmp/screen_locked2.png
 mv /tmp/screen_locked2.png /tmp/screen_locked.png
 i3lock -i /tmp/screen_locked.png


### PR DESCRIPTION
On 24.04, `import -window root` is very slow when saving to a .png. Saving to a .bmp makes locking the screen much faster. Note I'm still using `convert` to scale down the result to a .png file.